### PR TITLE
Release v1.3.2 and 

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.3.2-dev
+## v1.3.2
 
 - fix build
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdp-connector"
-version = "1.3.2-dev"
+version = "1.3.2"
 description = "RDP Connector"
 authors = ["Mike Boddin"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "rdp-connector",
-  "version": "1.3.2-dev",
+  "version": "1.3.2",
   "identifier": "net.autorisiert.rdp-connector",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Updates the `actions/checkout` GitHub Action from version 6 to 7 in the backend test workflow. This ensures the CI pipeline utilizes the latest stable and secure version of the action.